### PR TITLE
allows cog to run from folders deeper than the project root

### DIFF
--- a/bin/cog
+++ b/bin/cog
@@ -18,21 +18,40 @@ get_script_dir () {
      echo "$DIR"
 }
 
-# Yarn global adds the cog binary to your $PATH through a bunch of 
-# symlinks. So this uses the get_script_dir function to find the 
+# Yarn global adds the cog binary to your $PATH through a bunch of
+# symlinks. So this uses the get_script_dir function to find the
 # directory containing the cog script and then navigates up the tree
-DIR=$(dirname $(get_script_dir))
+SCRIPT_DIR=$(dirname $(get_script_dir))
+
+# function to get the project directory by scanning up the directory
+# hierarchy looking for a bin folder or a .cogconfig file
+get_project_dir () {
+    CHECK=$(pwd)
+    while [ -d "$CHECK" ] && [ "$CHECK" != "/" ]; do
+        if [ -f "$CHECK/.cogfile" ]; then
+            echo $CHECK
+            break
+        fi
+        if [ -d "$CHECK/bin" ]; then
+            echo "$CHECK"
+            break
+        fi
+        CHECK="$(dirname "$CHECK")"
+    done
+}
+PROJECT_DIR=$(get_project_dir)
 
 # Include all scripts inside the tools folder
-for file in $DIR/tools/*; do
+for file in $SCRIPT_DIR/tools/*; do
   source $file
 done
 
 # Drop next argument
 shift
 
-# load up .cogconfig
+# load up user cog config first and then allow a project cogconfig to override
 source ~/.cogconfig &>/dev/null
+source "$PROJECT_DIR/.cogconfig" &>/dev/null
 
 # split the .cogconfig variable by comma
 IFS=, read -a plugin_directories <<< "$COG_PLUGIN_DIRECTORIES"
@@ -43,7 +62,8 @@ IFS=, read -a plugin_directories <<< "$COG_PLUGIN_DIRECTORIES"
 BIN_DIRECTORIES=()
 BIN_DIRECTORIES+=( "./bin" )
 BIN_DIRECTORIES+=( ${plugin_directories[@]} )
-BIN_DIRECTORIES+=( "$DIR/bin" )
+BIN_DIRECTORIES+=( "$SCRIPT_DIR/bin" )
+BIN_DIRECTORIES+=( "$PROJECT_DIR/bin" )
 
 # Export Variables for use in cog commands later
 
@@ -54,7 +74,7 @@ export COG_PATH=${DIR}
 for bin_dir in "${BIN_DIRECTORIES[@]}"
 do
 	if [ -f ${bin_dir}/cog-${CMD} ]; then
-    	( set -a; source .env &> /dev/null; "${bin_dir}/cog-$CMD" "${@}")
+    	( set -a; source .env &> /dev/null; source "$PROJECT_DIR/.cogconfig" &>/dev/null;  "${bin_dir}/cog-$CMD" "${@}")
     	break
     fi		
 done

--- a/bin/cog-issue
+++ b/bin/cog-issue
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+if [ "$ISSUE_URL" == "" ]; then
+    echo "No ISSUE_URL set!"
+    echo "Add an ISSUE_URL variable to your project's .cogconfig file. For example,"
+    echo ""
+    echo "    ISSUE_URL=https://github.com/org/repo/issues/$1"
+    echo ""
+    exit
+fi
+
+open $ISSUE_URL


### PR DESCRIPTION
this is helpful if your project root/bin folder is not the same as where your typical PWD is. For example, we'll usually have the project root contain the bin folder but the `artisan` or `./craft` CLIs live inside a `html` directory. In this case you could now run `cog` from inside the `html` dir and it would still find `../bin/cog-*` files.

To test this out the PR also adds a `cog issue` command that you could run with a project. E.g., you could run `cog issue 123` inside a project directory and your browser would open with the correct URL.