### PR TITLE
Update set options to be stricter on when to exit

### DIFF
--- a/bin/cog
+++ b/bin/cog
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -o pipefail
+set -euo pipefail
 
 CMD=${1:-help}
 


### PR DESCRIPTION
@markhuot @dreadfullyposh Any reason not to use `set -euo pipefail` for the main `cog` script?

In this example, the script did not exit as I was intending, where adding the above fixed it:

1. I have 2 cog commands, `cog shell` and `cog build`
2. `cog shell` is a wrapper for `docker-compose exec node`
3. `cog build` does a `cog shell npm ci` and a `cog shell npm run build`
4. if the `cog shell npm ci` exits for any reason, `cog build` continues on to `cog shell npm run build` when it should exit entirely