### PR TITLE
Notify when Cog can’t find the specified command

### DIFF
--- a/bin/cog
+++ b/bin/cog
@@ -6,16 +6,16 @@ CMD=${1:-help}
 
 # function to get the directory containing cog
 get_script_dir () {
-     SOURCE="${BASH_SOURCE[0]}"
-     # While $SOURCE is a symlink, resolve it
-     while [ -h "$SOURCE" ]; do
-          DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-          SOURCE="$( readlink "$SOURCE" )"
-          # If $SOURCE was a relative symlink (so no "/" as prefix, need to resolve it relative to the symlink base directory
-          [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
-     done
-     DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-     echo "$DIR"
+    SOURCE="${BASH_SOURCE[0]}"
+    # While $SOURCE is a symlink, resolve it
+    while [ -h "$SOURCE" ]; do
+        DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+        SOURCE="$( readlink "$SOURCE" )"
+        # If $SOURCE was a relative symlink (so no "/" as prefix, need to resolve it relative to the symlink base directory
+        [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+    done
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    echo "$DIR"
 }
 
 # Yarn global adds the cog binary to your $PATH through a bunch of 
@@ -25,7 +25,7 @@ DIR=$(dirname $(get_script_dir))
 
 # Include all scripts inside the tools folder
 for file in $DIR/tools/*; do
-  source $file
+    source $file
 done
 
 # Drop next argument
@@ -54,19 +54,19 @@ export COG_PATH=${DIR}
 COMMAND_FOUND=false
 for bin_dir in "${BIN_DIRECTORIES[@]}"
 do
-	if [ -f ${bin_dir}/cog-${CMD} ]; then
-      COMMAND_FOUND=true
-    	( set -a; source .env &> /dev/null; "${bin_dir}/cog-$CMD" "${@}")
-    	break
+    if [ -f ${bin_dir}/cog-${CMD} ]; then
+        COMMAND_FOUND=true
+        ( set -a; source .env &> /dev/null; "${bin_dir}/cog-$CMD" "${@}")
+        break
     fi
 done
 
 # Notify if no matching command was found in any of the bin directories
 if [ !$COMMAND_FOUND ]; then
-  echo -e "${RED}No \`${CMD}\` command found in any Cog directories:${NC}"
-  for bin_dir in "${BIN_DIRECTORIES[@]}"
-  do
-    echo -e "${RED} - $(cd $bin_dir; pwd)${NC}"
-  done
-  exit 1
+    echo -e "${RED}No \`${CMD}\` command found in any Cog directories:${NC}"
+    for bin_dir in "${BIN_DIRECTORIES[@]}"
+    do
+        echo -e "${RED} - $(cd $bin_dir; pwd)${NC}"
+    done
+    exit 1
 fi

--- a/bin/cog
+++ b/bin/cog
@@ -66,7 +66,7 @@ if [ !$COMMAND_FOUND ]; then
   echo -e "${RED}No \`${CMD}\` command found in any Cog directories:${NC}"
   for bin_dir in "${BIN_DIRECTORIES[@]}"
   do
-    echo -e "${RED} - ${bin_dir}"
+    echo -e "${RED} - $(cd $bin_dir; pwd)"
   done
   exit 1
 fi

--- a/bin/cog
+++ b/bin/cog
@@ -66,7 +66,7 @@ if [ !$COMMAND_FOUND ]; then
   echo -e "${RED}No \`${CMD}\` command found in any Cog directories:${NC}"
   for bin_dir in "${BIN_DIRECTORIES[@]}"
   do
-    echo -e "${RED} - $(cd $bin_dir; pwd)"
+    echo -e "${RED} - $(cd $bin_dir; pwd)${NC}"
   done
   exit 1
 fi

--- a/bin/cog
+++ b/bin/cog
@@ -51,10 +51,22 @@ BIN_DIRECTORIES+=( "$DIR/bin" )
 export COG_PLUGIN_DIRECTORIES=${COG_PLUGIN_DIRECTORIES}
 export COG_PATH=${DIR}
 
+COMMAND_FOUND=false
 for bin_dir in "${BIN_DIRECTORIES[@]}"
 do
 	if [ -f ${bin_dir}/cog-${CMD} ]; then
+      COMMAND_FOUND=true
     	( set -a; source .env &> /dev/null; "${bin_dir}/cog-$CMD" "${@}")
     	break
-    fi		
+    fi
 done
+
+# Notify if no matching command was found in any of the bin directories
+if [ !$COMMAND_FOUND ]; then
+  echo -e "${RED}No \`${CMD}\` command found in any Cog directories:${NC}"
+  for bin_dir in "${BIN_DIRECTORIES[@]}"
+  do
+    echo -e "${RED} - ${bin_dir}"
+  done
+  exit 1
+fi


### PR DESCRIPTION
When running a command that does not exist in any of the defined Cog directories, `cog` currently exits successfully without any message. 

This checks that Cog actually found a script to run for the command, and if not displays a message to the user: 
```bash
$ cog jibberish
No `jibberish` command found in any Cog directories:
 - /path/to/current/directory/bin
 - /Users/someuser/.my-cog-plugins
 - /Users/someuser/another-tool/bin
```

To help in troubleshooting, the error output lists out the directories Cog looked in, including any directories added to `COG_PLUGIN_DIRECTORIES`, and expands relative paths like `./bin` for clarity.